### PR TITLE
add missing package

### DIFF
--- a/RiceInstaller
+++ b/RiceInstaller
@@ -68,7 +68,7 @@ clear
 
 logo "Installing needed packages.."
 
-dependencias=(base-devel pacman-contrib bspwm polybar sxhkd alacritty brightnessctl dunst rofi lsd jq polkit-gnome git playerctl mpd ncmpcpp geany ranger mpc picom feh ueberzug maim pamixer libwebp webp-pixbuf-loader xorg-xprop xorg-xkill physlock papirus-icon-theme ttf-jetbrains-mono ttf-jetbrains-mono-nerd ttf-terminus-nerd ttf-inconsolata ttf-joypixels zsh)
+dependencias=(base-devel pacman-contrib bspwm polybar sxhkd alacritty brightnessctl dunst rofi lsd jq polkit-gnome git playerctl mpd ncmpcpp geany ranger mpc picom feh ueberzug maim pamixer libwebp webp-pixbuf-loader xorg-xprop xorg-xkill xorg-xwininfo physlock papirus-icon-theme ttf-jetbrains-mono ttf-jetbrains-mono-nerd ttf-terminus-nerd ttf-inconsolata ttf-joypixels zsh)
 
 is_installed() {
   pacman -Qi $1 &> /dev/null


### PR DESCRIPTION
The sxhkdrc file has a field:

> Change transparency on focused window

```ts
ctrl+alt {plus, minus, t}
     {picom-trans -c -o +3, picom-trans -c -o -1, picom-trans -c -d}
```

Which, with a clean installation of the arch system and distributions based on it, does not fulfill its task. This requires the addition of one xorg-xwininfo package.