### PR TITLE
Update RiceInstaller

### DIFF
--- a/RiceInstaller
+++ b/RiceInstaller
@@ -73,7 +73,7 @@ dependencias=(base-devel rustup pacman-contrib bspwm polybar sxhkd \
 			  feh ueberzug maim pamixer libwebp xdg-user-dirs \
 			  webp-pixbuf-loader xorg-xprop xorg-xkill physlock papirus-icon-theme \
 			  ttf-jetbrains-mono ttf-jetbrains-mono-nerd ttf-terminus-nerd ttf-inconsolata ttf-joypixels \
-			  zsh zsh-autosuggestions zsh-history-substring-search zsh-syntax-highlighting xorg-xsetroot xorg-xwininfo)
+			  zsh zsh-autosuggestions zsh-history-substring-search zsh-syntax-highlighting xorg-xsetroot xorg-xwininfo xorg-xrandr)
 
 is_installed() {
   pacman -Qi "$1" &> /dev/null


### PR DESCRIPTION
Added xorg-xrandr as it is a dependency for scratchpads
(Error: Xrandr must be installed to use -m / --monitor-aware)