### PR TITLE
corrected lsd aliases & deleted of firefox action buttons.

### DIFF
--- a/home/.zshrc
+++ b/home/.zshrc
@@ -125,8 +125,8 @@ alias vm-off="sudo systemctl stop libvirtd.service"
 
 alias musica="ncmpcpp"
 
-alias ls='lsd -a --group-directories-first'
-alias ll='lsd -la --group-directories-first'
+alias ls='lsd -a --group-dirs'
+alias ll='lsd -la --group-dirs'
 
 #  ┌─┐┬ ┬┌┬┐┌─┐  ┌─┐┌┬┐┌─┐┬─┐┌┬┐
 #  ├─┤│ │ │ │ │  └─┐ │ ├─┤├┬┘ │ 

--- a/misc/firefox/chrome/userChrome.css
+++ b/misc/firefox/chrome/userChrome.css
@@ -302,3 +302,6 @@ toolbarbutton.bookmark-item:hover,
 /*stops possible clashes with extension popups*/
 .webextension-popup-browser {
   background: #fff;}
+
+/* Remove main window buttons */
+.titlebar-buttonbox-container{ display:none }


### PR DESCRIPTION
1. lsd does not have `--group-directories-first` option as like normal ls command instead there is an option called `--group-dirs` thus configuring an alias in that way leads to the error below.

```bash
[user@host ~]$ ls 

error: Found argument '--group-directories-first' which wasn't expected, or isn't valid in this context
	Did you mean --group-dirs?

USAGE:
    lsd --group-dirs <group-dirs>...

For more information try --help
```

2. I've deleted those action buttons of Firefox(close, minimize, etc). I mean these are against the philosophy of tiling window managers. they don't even work.