### PR TITLE
Fix eww workspaces duplicating

### DIFF
--- a/config/bspwm/rices/andrea/andy/scripts/WorkSpaces
+++ b/config/bspwm/rices/andrea/andy/scripts/WorkSpaces
@@ -10,7 +10,7 @@ contains() {
 
 print_workspaces() {
     buf=""
-    desktops="$(bspc query -D --names)"
+    desktops="$(bspc query -D --names | sort | uniq)"
     focused_desktop="$(bspc query -D -d focused --names)"
     occupied_desktops="$(bspc query -D -d .occupied --names)"
 

--- a/config/bspwm/rices/z0mbi3/bar/scripts/WorkSpaces
+++ b/config/bspwm/rices/z0mbi3/bar/scripts/WorkSpaces
@@ -10,7 +10,7 @@ contains() {
 
 print_workspaces() {
     buf=""
-    desktops=$(bspc query -D --names)
+    desktops=$(bspc query -D --names | sort | uniq)
     focused_desktop=$(bspc query -D -d focused --names)
     occupied_desktops=$(bspc query -D -d .occupied --names)
 


### PR DESCRIPTION
Fixes https://github.com/gh0stzk/dotfiles/issues/207#issue-2198213495.

In the `WorkSpaces` script, you are looping through `desktops`:

```shell
for d in $desktops; do
		if [[ "$(contains "$focused_desktop" "$d")" -eq 1 ]]; then
			ws=$d
			icon="󰮯"
			class="workspace-focused"
		elif [[ "$(contains "$occupied_desktops" "$d")" -eq 1 ]]; then
			ws=$d
			icon="󰊠"
			class="workspace-occupied"
		else
			ws="$d"
			icon="󰑊"
			class="workspace-empty"
		fi

		buf+="(eventbox :cursor \"pointer\" (button :class \"$class\" :onclick \"bspc desktop -f $ws\" \"$icon\"))"
	done
```

The output of which; `bspc query -D --names`, looks like this:

![image](https://github.com/gh0stzk/dotfiles/assets/71812498/070fab42-af73-4615-8293-b49522915280)

This is why workspaces are duplicating when connecting an external desktop.

I fixed this by piping the output of `bspc query -D --names` to `sort` and then piping the output of `sort` to `uniq`. Now the query looks like this:

![image](https://github.com/gh0stzk/dotfiles/assets/71812498/dcc241cb-1425-4bd7-bac9-911bdcdd9992)

And now workspaces are not duplicating anymore (when connecting an external desktop), and they are working just like the workspaces in polybar:

![image](https://github.com/gh0stzk/dotfiles/assets/71812498/e72698e1-a39f-4557-9223-f9c9ff353710)
![image](https://github.com/gh0stzk/dotfiles/assets/71812498/4d534b19-37c6-4dc0-8478-65dabf2a33cb)