### PR TITLE
Add alias for lsblk with extended output options

### DIFF
--- a/home/.zshrc
+++ b/home/.zshrc
@@ -142,6 +142,7 @@ alias music="ncmpcpp"
 alias cat="bat --theme=base16"
 alias ls='eza --icons=always --color=always -a'
 alias ll='eza --icons=always --color=always -la'
+alias lsblk='lsblk -o NAME,RM,SIZE,TYPE,MOUNTPOINT,FSUSED,FSAVAIL,FSTYPE'
 
 #  ┌─┐┬ ┬┌┬┐┌─┐  ┌─┐┌┬┐┌─┐┬─┐┌┬┐
 #  ├─┤│ │ │ │ │  └─┐ │ ├─┤├┬┘ │


### PR DESCRIPTION
Added an alias for lsblk to display detailed information including FSUSED and FSAVAIL: alias lsblk='lsblk -o NAME,RM,SIZE,TYPE,MOUNTPOINT,FSUSED,FSAVAIL,FSTYPE'