### PR TITLE
Fixed battery icon not showing in z0mbi3 theme

### DIFF
--- a/config/bspwm/rices/z0mbi3/bar/scripts/battery
+++ b/config/bspwm/rices/z0mbi3/bar/scripts/battery
@@ -14,13 +14,13 @@ icon() {
     elif [ "$per" -gt "70" ]; then
         icon="images/battery_70.png"
     elif [ "$per" -gt "60" ]; then
-        icon="images/battery-50.svg"
+        icon="images/battery_50.png"
     elif [ "$per" -gt "50" ]; then
-        icon="images/battery-50.svg"
+        icon="images/battery_50.png"
     elif [ "$per" -gt "40" ]; then
-        icon="images/battery-30.svg"
+        icon="images/battery_30.png"
     elif [ "$per" -gt "30" ]; then
-        icon="images/battery-30.svg"
+        icon="images/battery_30.png"
     elif [ "$per" -gt "20" ]; then
         icon="images/battery_20.png"
     elif [ "$per" -gt "10" ]; then


### PR DESCRIPTION
The conditions for 60%, 50%, 40%, 30% had the image name wrong for the battery icon

![image](https://github.com/user-attachments/assets/62ec4303-f3c9-4be8-9b02-4b26c6502c53)

Fixed by changing the names to the actual names in `images` directory

![image](https://github.com/user-attachments/assets/08c3a859-8c94-4170-9098-c52bb94bdc77)

Closes #383 
