### PR TITLE
Added minimum brightness threshold

### DIFF
--- a/config/bspwm/src/Brightness
+++ b/config/bspwm/src/Brightness
@@ -3,6 +3,7 @@
 
 DIR="$HOME/.config/bspwm/src/assets"
 BRIGHTNESS_STEPS=5
+MIN_BRIGHTNESS=2
 
 function get_brightness {
   brightnessctl i | grep -oP '\(\K[^%\)]+'
@@ -18,15 +19,38 @@ function send_notification {
   dunstify "Brightness $brightness%" -i $icon -r 5555 -u normal -h int:value:$(($brightness))
 }
 
+function adjust_brightness {
+  current=$(get_brightness)
+  
+  case $1 in
+    up)
+      if [ "$current" -eq $MIN_BRIGHTNESS ]; then
+        # If at 2%, go to 5%
+        brightnessctl set 5% -q
+      else
+        # Normal 5% increase
+        brightnessctl set "${BRIGHTNESS_STEPS:-5}%+" -q
+      fi
+      ;;
+    down)
+      if [ "$current" -le $((MIN_BRIGHTNESS + BRIGHTNESS_STEPS)) ]; then
+        # If at or below 7%, go to 2%
+        brightnessctl set $MIN_BRIGHTNESS% -q
+      else
+        # Normal 5% decrease
+        brightnessctl set "${BRIGHTNESS_STEPS:-5}%-" -q
+      fi
+      ;;
+  esac
+  
+  send_notification
+}
+
 case $1 in
   up)
-    # increase the backlight by 5%
-    brightnessctl set "${BRIGHTNESS_STEPS:-5}%+" -q
-    send_notification
+    adjust_brightness up
     ;;
   down)
-    # decrease the backlight by 5%
-    brightnessctl set "${BRIGHTNESS_STEPS:-5}%-" -q
-    send_notification
+    adjust_brightness down
     ;;
 esac

--- a/config/bspwm/src/Brightness
+++ b/config/bspwm/src/Brightness
@@ -25,7 +25,7 @@ function adjust_brightness {
   case $1 in
     up)
       if [ "$current" -eq $MIN_BRIGHTNESS ]; then
-        # If at 2%, go to 5%
+        # If at MIN_BRIGHTNESS, go to 5%
         brightnessctl set 5% -q
       else
         # Normal 5% increase
@@ -34,7 +34,7 @@ function adjust_brightness {
       ;;
     down)
       if [ "$current" -le $((MIN_BRIGHTNESS + BRIGHTNESS_STEPS)) ]; then
-        # If at or below 7%, go to 2%
+        # If at or below 7%, go to MIN_BRIGHTNESS
         brightnessctl set $MIN_BRIGHTNESS% -q
       else
         # Normal 5% decrease


### PR DESCRIPTION
Addressing issue #402, I added a MIN_BRIGHTNESS variable to the brightness script. And made a function so that if the brightness is at 5%, pressing brightness down will only lower brightness to MIN_BRIGHTNESS and pressing brightness up from MIN_BRIGHTNES will, instead of adding 5%, go directly to 5% then carry on with the usual 5% increments.