### PR TITLE
Fix icon with rounded border in RiceSelector.rasi

### DIFF
--- a/config/bspwm/src/rofi-themes/RiceSelector.rasi
+++ b/config/bspwm/src/rofi-themes/RiceSelector.rasi
@@ -86,6 +86,7 @@ element-icon {
     cursor:                      inherit;
     border-radius:               20px;
     background-color:            transparent;
+    margin:			 7px;
     text-color:                  inherit;
 }
 element-text {


### PR DESCRIPTION
![shot](https://github.com/user-attachments/assets/5c4aa35d-b62a-499c-93cb-876abb2dfb93)
