### PR TITLE
Fixing some Bluetooth devices not showing correctly

### DIFF
--- a/config/bspwm/eww/profilecard/scripts/Bluetooth
+++ b/config/bspwm/eww/profilecard/scripts/Bluetooth
@@ -36,9 +36,9 @@ get_icon() {
 get_name() {
     if has_bluetooth; then
         if bluetoothctl show | grep -q "Powered: yes"; then
-            connected_devices=$(bluetoothctl devices Connected | awk '{print $3}')
+            connected_devices=$(bluetoothctl info | grep "Name" | sed 's/^\s*Name: //')
             if [ -n "$connected_devices" ]; then
-                echo "$connected_devices"
+                echo "$connected_devices" | paste -sd ", "
             else
                 echo "On"
             fi
@@ -49,6 +49,7 @@ get_name() {
         echo "Null"
     fi
 }
+
 
 # Function to toggle Bluetooth status
 toggle() {

--- a/config/bspwm/eww/profilecard/scripts/Bluetooth
+++ b/config/bspwm/eww/profilecard/scripts/Bluetooth
@@ -38,7 +38,7 @@ get_name() {
         if bluetoothctl show | grep -q "Powered: yes"; then
             connected_devices=$(bluetoothctl info | grep "Name" | sed 's/^\s*Name: //')
             if [ -n "$connected_devices" ]; then
-                echo "$connected_devices" | paste -sd ", "
+                echo "$connected_devices" | awk '{s = s $0 ", "} END {sub(", $", "", s); print s}'
             else
                 echo "On"
             fi
@@ -49,7 +49,6 @@ get_name() {
         echo "Null"
     fi
 }
-
 
 # Function to toggle Bluetooth status
 toggle() {


### PR DESCRIPTION
Hola @gh0stzk espero que te encuentre muy bien, volvi a re-instalar tus dotfiles en mi computadora y siempre que conecto mis audifonos bluetooth el nombre no se muestra correctamente en el widget profilecard, espesificamente el script bluetooth.

Esto es como se ve ahora.
![image](https://github.com/user-attachments/assets/c37a5947-07be-4a64-b614-f18d30ecba76)

Esto es como se ve antes.
![image](https://github.com/user-attachments/assets/db616138-b194-4bbf-bd9e-ebd15e63b940)

el problema es que si hay más de un dispositivo conectado, bluetoothctl imprime una línea por dispositivo, solo extrae el tercer campo, que generalmente es solo el primer nombre, y si el nombre tiene espacios, ahí viene el bug visual