### PR TITLE
Fix: Adaptive lockscreen positioning for multiple screen resolutions

### DIFF
--- a/config/bspwm/bin/ScreenLocker
+++ b/config/bspwm/bin/ScreenLocker
@@ -20,12 +20,12 @@
 TEMP_IMAGE="/tmp/i3lock.jpg"
 
 # Colors
-bg=1a1b26
-fg=c0caf5
-ring=15161e
-wrong=f7768e
-date=c0caf5
-verify=9ece6a
+bg=#1a1b26
+fg=#c0caf5
+ring=#15161e
+wrong=#f7768e
+date=#c0caf5
+verify=#9ece6a
 
 # Get screen resolution dynamically
 get_screen_resolution() {
@@ -47,7 +47,11 @@ get_screen_resolution() {
 # Calculate positions based on screen resolution
 calculate_positions() {
     # Center horizontally
-    CENTER_X=$((SCREEN_WIDTH / 2))
+    CENTER_X=$((SCREEN_WIDTH * 25 / 100))  # Left position... 25% of screen width
+
+    # Some other options:
+    # CENTER_X=$((SCREEN_WIDTH / 2)) # Exact center (uncomment if preferred)
+    # CENTER_X=$((SCREEN_WIDTH * 75 / 100)) # Right position...
     
     # Calculate vertical positions as percentages of screen height
     # Adjust these percentages to your preference
@@ -62,7 +66,7 @@ calculate_positions() {
     # Base sizes for 1920x1080, scale for other resolutions
     BASE_WIDTH=1920
     BASE_HEIGHT=1080
-    
+   
     # Scale factor formula...
     SCALE_FACTOR=$(echo "scale=2; sqrt(($SCREEN_WIDTH * $SCREEN_HEIGHT) / ($BASE_WIDTH * $BASE_HEIGHT))" | bc)
     


### PR DESCRIPTION
Previously, all UI elements (time, date, indicator, text) were positioned using **hardcoded** pixel values :(, causing misalignment on monitors with different resolutions.

### Changes:
- Added dynamic screen resolution detection using `xrandr`/`xdpyinfo`
- Implemented percentage-based positioning for all UI elements
- Added automatic font and indicator scaling based on screen size
- Fixed duplicate -`-verif-pos` parameter in i3lock command

The lockscreen now adapts properly to any monitor resolution, from 1366x768 to 4K and beyond, maintaining proper proportions and alignment.