### PR TITLE
Update MonitorSetup to fix the primary monitor.

### DIFF
--- a/config/bspwm/bin/MonitorSetup
+++ b/config/bspwm/bin/MonitorSetup
@@ -31,7 +31,7 @@ get_monitor_info() {
 }
 
 # Get connected monitors using POSIX-compliant method
-set -- $(echo "$XRANDR_OUTPUT" | awk '$2 == "connected" {print $1}')
+set -- $(xrandr --listactivemonitors | grep "[0-9]:" | awk '{print $4}')
 NUM_MONITORS=$#
 
 # Main case for monitor configuration


### PR DESCRIPTION
The special feature of `xrandr --listactivemonitors` is that the first monitor in the list will be the primary monitor. This is very convenient because the rest of the script uses the first monitor in the list as the primary monitor. This allows you to set the primary monitor once using `xrandr --output HDMI-0 --primary` in the terminal or a third-party application like `nvidia-settings`.