### PR TITLE
overall fix for keybinds for all non-latin keymaps

### DIFF
--- a/config/bspwm/bin/KeyBoardL
+++ b/config/bspwm/bin/KeyBoardL
@@ -15,8 +15,7 @@
 # Licensed under GPL-3.0 license
 # =============================================================
 
-# Get the current layout
-CURRENT=$(setxkbmap -query | awk '/layout/ {print $2}')
+CURRENT=$(setxkbmap -query | awk '/layout/ {print $2}' | cut -d',' -f1)
 
 # Layouts. You can add yours.
 LAYOUTS="US English|us
@@ -46,6 +45,6 @@ if [ -n "$selected" ]; then
         set -f
         set -- $layout_code
         set +f
-        setxkbmap "$@"
+        setxkbmap -option ctrl:nocaps "$@,us"
     fi
 fi


### PR DESCRIPTION
by adding the ctrl:nocaps option and adding ,us after the layout (for some reason) all the keybinds starts to work completely fine. i also made it so it will cut off the ,us part from the $CURRENT so it wont display the ,us part in the rofi menu. basically fixed the issue https://github.com/gh0stzk/dotfiles/issues/577 i opened